### PR TITLE
Fixing typo in iterator page

### DIFF
--- a/290_iterator.Rmd
+++ b/290_iterator.Rmd
@@ -17,11 +17,11 @@ The figure below shows schematically how to access vector elements using an iter
 
 ![](iterator.png)
 
-* `i = v.begin()` : The iterator `i` points to the first element of` v`.
+* `i = v.begin()` : The iterator `i` points to the first element of `v`.
 * `++i` : Updates `i` to the state pointing to the next element.
 * `--i` : Updates `i` to the state pointing to the previous element.
-* `i + 1` : Represents an iterator pointing to the element 1 elements behind of `i`.
-* `i - 1` : Represents an iterator pointing to the element 1 elements ahead of `i`.
+* `i + 1` : Represents an iterator pointing to the element 1 element ahead of `i`.
+* `i - 1` : Represents an iterator pointing to the element 1 element behind `i`.
 * `*i` : Represents the value of the element pointed by `i`.
 * `v.end()` : Represents an iterator pointing to the end (one after the last element) of `v`.
 * `*(v.begin()+k)` : Represents the value of the `k`-th element of `v` (`v[k]`).

--- a/290_iterator.Rmd
+++ b/290_iterator.Rmd
@@ -20,8 +20,8 @@ The figure below shows schematically how to access vector elements using an iter
 * `i = v.begin()` : The iterator `i` points to the first element of `v`.
 * `++i` : Updates `i` to the state pointing to the next element.
 * `--i` : Updates `i` to the state pointing to the previous element.
-* `i + 1` : Represents an iterator pointing to the element 1 element ahead of `i`.
-* `i - 1` : Represents an iterator pointing to the element 1 element behind `i`.
+* `i + 1` : Represents the iterator pointing to the next element (one element after `i`).
+* `i - 1` : Represents the iterator pointing to the previous element (one element before `i`).
 * `*i` : Represents the value of the element pointed by `i`.
 * `v.end()` : Represents an iterator pointing to the end (one after the last element) of `v`.
 * `*(v.begin()+k)` : Represents the value of the `k`-th element of `v` (`v[k]`).


### PR DESCRIPTION
Hello @teuder,

Thanks for the fun book! I noticed a small typographical error in the iterator page. It looks like iterator addition and subtraction were switched around. I have made the edit in one commit, but did not rebuild the book.

Please let me know if you have any questions or comments.